### PR TITLE
Fix code scanning alert no. 16: Uncontrolled data used in path expression

### DIFF
--- a/completesolution/springboot/copilot-demo/src/main/java/com/microsoft/hackathon/copilotdemo/controller/DemoController.java
+++ b/completesolution/springboot/copilot-demo/src/main/java/com/microsoft/hackathon/copilotdemo/controller/DemoController.java
@@ -193,7 +193,12 @@ public class DemoController {
     @GetMapping("/zip-folder")
     public ResponseEntity<Resource> zipFolder(@RequestParam(name = "path") String pathString) {
         try {
-            File folder = new File(pathString);
+            Path baseDir = Paths.get("/safe/base/directory").normalize().toAbsolutePath();
+            Path folderPath = baseDir.resolve(pathString).normalize().toAbsolutePath();
+            if (!folderPath.startsWith(baseDir)) {
+                return ResponseEntity.badRequest().body(null);
+            }
+            File folder = folderPath.toFile();
             if (!folder.exists()) {
                 return ResponseEntity.notFound().build();
             }


### PR DESCRIPTION
Fixes [https://github.com/zjaveed-sand-org/CopilotHackathon/security/code-scanning/16](https://github.com/zjaveed-sand-org/CopilotHackathon/security/code-scanning/16)

To fix the problem, we need to validate the user-provided `pathString` before using it to create a `File` object. The validation should ensure that the path is within a specific directory and does not contain any path traversal sequences like "..". We can achieve this by resolving the path against a known safe base directory and checking that the resulting path is still within that directory.

1. Define a base directory where the zipping operation is allowed.
2. Resolve the user-provided path against this base directory.
3. Normalize the resulting path and check that it starts with the base directory path.
4. If the validation fails, return an appropriate error response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
